### PR TITLE
A reminder action for the reviewers on prs

### DIFF
--- a/.github/script.js
+++ b/.github/script.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const moment = require("moment");
+const { Octokit } = require("@octokit/action");
+const owner = process.env.GITHUB_REPOSITORY.split("/")[0];
+const repo = process.env.GITHUB_REPOSITORY.split("/")[1];
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+async function run() {
+  console.log("Fetching open pull requests...");
+  const prs = await octokit.request("GET /repos/{owner}/{repo}/pulls", {
+    owner: owner,
+    repo: repo,
+    state: "open",
+  });
+  console.log("Open pull requests fetched:", prs.data.length);
+
+  for (const pr of prs.data) {
+    console.log(`Processing pull request #${pr.number}...`);
+    console.log(`Fetching reviews for pull request #${pr.number}`);
+
+    const reviews = await octokit.request(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+      {
+        owner: owner,
+        repo: repo,
+        pull_number: pr.number,
+      }
+    );
+    // Fetch the list of potential reviewers
+    const potentialReviewersResponse = await octokit.request(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+      {
+        owner: owner,
+        repo: repo,
+        pull_number: pr.number,
+      }
+    );
+    const potentialReviewers = potentialReviewersResponse.data.users.map(
+      (user) => user.login
+    );
+
+    // Find the reviewers who haven't made a review
+    const reviewers = reviews.data.map((review) => review.user.login);
+    const reviewersWhoHaventReviewed = potentialReviewers.filter(
+      (reviewer) => !reviewers.includes(reviewer)
+    );
+
+    console.log(
+      `Reviewers who haven't reviewed the pull request #${pr.number}:`,
+      reviewersWhoHaventReviewed
+    );
+    const joinedAt = reviewersWhoHaventReviewed[0].joined_at;
+    const joinedAtTime = moment(joinedAt);
+    const now = moment();
+    const hoursSinceJoined = now.diff(joinedAtTime, "hours");
+    console.log(`The approver has been joined for ${hoursSinceJoined} hours.`);
+
+    if (hoursSinceJoined > 1) {
+      reviewersWhoHaventReviewed.forEach(async (reviewer, index) => {
+        // Mention the reviewer in a comment on the pull request
+        await octokit.request(
+          "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+          {
+            owner: owner,
+            repo: repo,
+            issue_number: pr.number,
+            body: `Hi @${reviewer}, don't forget to check this PR.`,
+          }
+        );
+      });
+    }
+  }
+}
+
+run().catch(console.error);

--- a/.github/workflows/pr-reminder.yml
+++ b/.github/workflows/pr-reminder.yml
@@ -1,0 +1,28 @@
+name: pr-reminder
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: installation
+        run: |
+          echo '{}' > package.json
+          npm install
+          npm install moment
+          npm install @octokit/action
+      - name: Run script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/script.js


### PR DESCRIPTION
### Pull Request Description: "A Reminder Action for Pull Request Reviewers"

This PR introduces a scheduled GitHub Action to assist in managing and tracking pull request reviews. The action, triggered daily or on demand, checks for open pull requests in the repository and identifies any reviewers who have not yet provided feedback. If a reviewer has been assigned for over an hour and hasn’t submitted a review, the action will post a gentle reminder for them to check the PR.

**Key Changes:**

1. **Reminder Script (`script.js`):**  
   - Fetches all open pull requests.
   - Retrieves lists of reviewers and compares them to those who have submitted reviews.
   - Identifies assigned reviewers who haven’t reviewed the PR within a one-hour timeframe and posts a reminder comment tagging the reviewer.

2. **GitHub Workflow (`pr-reminder.yml`):**  
   - Runs on a daily cron schedule and can be triggered manually.
   - Uses the Node.js environment, with dependencies like `moment` for date handling and `@octokit/action` for GitHub API interactions.
   - Requires `pull-requests: write` permissions to enable commenting on PRs.

This action helps streamline the PR review process by gently nudging reviewers and ensuring that PRs don’t go unattended.